### PR TITLE
NEW Adds caller to ivy-read

### DIFF
--- a/my-fuzzy-cmd-selector.el
+++ b/my-fuzzy-cmd-selector.el
@@ -42,7 +42,8 @@
   (unless mfcs-commands (error "mfcs-commands is empty"))
   (-let* ((chosen-desc (ivy-read "Command: "
                                  (-map #'mfcs--get-desc mfcs-commands)
-                                 :require-match t)))
+                                 :require-match t
+                                 :caller :mfcs-call)))
     (->> mfcs-commands
          (-first (lambda (x) (string= (funcall #'mfcs--get-desc x) chosen-desc)))
          mfcs--get-func


### PR DESCRIPTION
This allows, for example, specifying the height with `ivy-height-alist`