### PR TITLE
FIX uses `call-interactively` to allow passing functions to mfcs-add

### DIFF
--- a/my-fuzzy-cmd-selector.el
+++ b/my-fuzzy-cmd-selector.el
@@ -47,7 +47,7 @@
     (->> mfcs-commands
          (-first (lambda (x) (string= (funcall #'mfcs--get-desc x) chosen-desc)))
          mfcs--get-func
-         funcall-interactively)))
+         call-interactively)))
 
 (provide 'my-fuzzy-cmd-selector)
 ;; my-fuzzy-cmd-selector.el ends here


### PR DESCRIPTION
- With funcall-interactively something like this
  `(mfcs-add ... :command #'compile)` would fail, because funcall
  `interactively` parses no arguments, while `call-interactively`
  parses arguments as an interactive call